### PR TITLE
Pull Working Changes into Main

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -33,7 +33,7 @@ export default function Index() {
             </BreadcrumbBar>
             <div className="flex justify-center">
                 <CardGroup className="flex justify-center">
-                    <Card className="mx-auto min-w-[41rem] max-w-[63rem]">
+                    <Card className="min-w-[41rem] max-w-[63rem]">
                         <CardHeader>
                             <h1 className="font usa-card__heading font-bold py-2">
                                 Meeting Spaces

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,4 +1,12 @@
-import { Card, CardGroup, CardHeader, Header } from "@trussworks/react-uswds";
+import {
+    Breadcrumb,
+    BreadcrumbBar,
+    BreadcrumbLink,
+    Card,
+    CardGroup,
+    CardHeader,
+    Header,
+} from "@trussworks/react-uswds";
 import { mergeMeta } from "~/lib/merge-meta";
 
 export const meta = mergeMeta(({ parentTitle }) => [{ title: `Meeting Spaces • ${parentTitle}` }]);
@@ -12,13 +20,20 @@ export default function Index() {
                         alt="Public Meeting Room"
                         className="min-w-[40rem] max-w-[62rem] object-contain"
                         loading="lazy"
-                        src="public\meetingSpacesHeader.jpg"
+                        src="/meetingSpacesHeader.jpg"
                     />
                 </div>
             </Header>
+            <BreadcrumbBar>
+                <Breadcrumb>
+                    <BreadcrumbLink href="#">
+                        <span>Home</span>
+                    </BreadcrumbLink>
+                </Breadcrumb>
+            </BreadcrumbBar>
             <div className="flex justify-center">
                 <CardGroup className="flex justify-center">
-                    <Card className="mx-auto min-w-[38rem] max-w-[63rem]">
+                    <Card className="mx-auto min-w-[41rem] max-w-[63rem]">
                         <CardHeader>
                             <h1 className="font usa-card__heading font-bold py-2">
                                 Meeting Spaces

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -24,13 +24,15 @@ export default function Index() {
                     />
                 </div>
             </Header>
-            <BreadcrumbBar>
-                <Breadcrumb>
-                    <BreadcrumbLink href="#">
-                        <span>Home</span>
-                    </BreadcrumbLink>
-                </Breadcrumb>
-            </BreadcrumbBar>
+            <div className="flex justify-center">
+                <BreadcrumbBar className="min-w-[40rem]">
+                    <Breadcrumb>
+                        <BreadcrumbLink href="#">
+                            <span>Home</span>
+                        </BreadcrumbLink>
+                    </Breadcrumb>
+                </BreadcrumbBar>
+            </div>
             <div className="flex justify-center">
                 <CardGroup className="flex justify-center">
                     <Card className="min-w-[41rem] max-w-[63rem]">

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -10,7 +10,7 @@ export default function Index() {
                 <div className="flex justify-center">
                     <img
                         alt="Public Meeting Room"
-                        className="min-w-[36rem] max-w-[62rem] object-contain"
+                        className="min-w-[40rem] max-w-[62rem] object-contain"
                         loading="lazy"
                         src="public\meetingSpacesHeader.jpg"
                     />

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -9,28 +9,31 @@ export default function Index() {
             <Header>
                 <div className="flex justify-center">
                     <img
-                        src="public\meetingSpacesHeader.jpg"
                         alt="Public Meeting Room"
-                        typeof="Image"
+                        className="min-w-[36rem] max-w-[62rem] object-contain"
                         loading="lazy"
-                        className="min-w-[40rem] max-w-[62rem] object-contain"
+                        src="public\meetingSpacesHeader.jpg"
                     />
                 </div>
             </Header>
-            <CardGroup className="flex justify-center">
-                <Card className="mx-auto min-w-[40rem] max-w-[63rem]">
-                    <CardHeader>
-                        <h1 className="font usa-card__heading font-bold py-2">Meeting Spaces</h1>
-                        <p className="font-sans text-base-darker text-left mx-4">
-                            Austin Public Library Meeting Spaces are
-                            <strong className="font-bold"> free of charge</strong> and ideal for
-                            discussion groups, panels, and lectures. Both paper and online
-                            reservation requests are timestamped and processed in the order they are
-                            received.
-                        </p>
-                    </CardHeader>
-                </Card>
-            </CardGroup>
+            <div className="flex justify-center">
+                <CardGroup className="flex justify-center">
+                    <Card className="mx-auto min-w-[38rem] max-w-[63rem]">
+                        <CardHeader>
+                            <h1 className="font usa-card__heading font-bold py-2">
+                                Meeting Spaces
+                            </h1>
+                            <p className="font-sans text-base-darker text-left mx-4">
+                                Austin Public Library Meeting Spaces are
+                                <strong className="font-bold"> free of charge</strong> and ideal for
+                                discussion groups, panels, and lectures. Both paper and online
+                                reservation requests are timestamped and processed in the order they
+                                are received.
+                            </p>
+                        </CardHeader>
+                    </Card>
+                </CardGroup>
+            </div>
         </>
     );
 }

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,22 +1,31 @@
-import { Card, CardGroup, CardHeader } from "@trussworks/react-uswds";
+import { Card, CardGroup, CardHeader, Header } from "@trussworks/react-uswds";
 import { mergeMeta } from "~/lib/merge-meta";
 
 export const meta = mergeMeta(({ parentTitle }) => [{ title: `Meeting Spaces • ${parentTitle}` }]);
 
 export default function Index() {
     return (
-        <CardGroup>
-            <Card>
-                <CardHeader>
-                    <h1 className="usa-card__heading">Meeting Spaces</h1>
-                    <p className="font-sans text-base-darker">
-                        Austin Public Library Meeting Spaces are
-                        <strong className="font-bold"> free of charge</strong> and ideal for
-                        discussion groups, panels, and lectures. Both paper and online reservation
-                        requests are timestamped and processed in the order they are received.
-                    </p>
-                </CardHeader>
-            </Card>
-        </CardGroup>
+        <>
+            <Header>
+                <img
+                    src="public\meetingSpacesHeader.jpg"
+                    className="max-w-5xl max-h-52 justify-center"
+                />
+            </Header>
+            <CardGroup>
+                <Card>
+                    <CardHeader>
+                        <h1 className="usa-card__heading">Meeting Spaces</h1>
+                        <p className="font-sans text-base-darker">
+                            Austin Public Library Meeting Spaces are
+                            <strong className="font-bold"> free of charge</strong> and ideal for
+                            discussion groups, panels, and lectures. Both paper and online
+                            reservation requests are timestamped and processed in the order they are
+                            received.
+                        </p>
+                    </CardHeader>
+                </Card>
+            </CardGroup>
+        </>
     );
 }

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -18,7 +18,7 @@ export default function Index() {
                 </div>
             </Header>
             <CardGroup className="flex justify-center">
-                <Card className="m-auto min-w-[40rem] max-w-[63rem]">
+                <Card className="mx-auto min-w-[40rem] max-w-[63rem]">
                     <CardHeader>
                         <h1 className="font usa-card__heading font-bold py-2">Meeting Spaces</h1>
                         <p className="font-sans text-base-darker text-left mx-4">

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -7,16 +7,21 @@ export default function Index() {
     return (
         <>
             <Header>
-                <img
-                    src="public\meetingSpacesHeader.jpg"
-                    className="max-w-5xl max-h-52 justify-center"
-                />
+                <div className="flex justify-center">
+                    <img
+                        src="public\meetingSpacesHeader.jpg"
+                        alt="Public Meeting Room"
+                        typeof="Image"
+                        loading="lazy"
+                        className="min-w-[600px] max-w-[1200px] min-h-[400px] max-h-[300px] object-contain"
+                    />
+                </div>
             </Header>
             <CardGroup>
                 <Card>
                     <CardHeader>
-                        <h1 className="usa-card__heading">Meeting Spaces</h1>
-                        <p className="font-sans text-base-darker">
+                        <h1 className="font usa-card__heading font-bold py-2">Meeting Spaces</h1>
+                        <p className="font-sans text-base-darker text-left">
                             Austin Public Library Meeting Spaces are
                             <strong className="font-bold"> free of charge</strong> and ideal for
                             discussion groups, panels, and lectures. Both paper and online

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -13,15 +13,15 @@ export default function Index() {
                         alt="Public Meeting Room"
                         typeof="Image"
                         loading="lazy"
-                        className="min-w-[600px] max-w-[1200px] min-h-[400px] max-h-[300px] object-contain"
+                        className="min-w-[40rem] max-w-[62rem] object-contain"
                     />
                 </div>
             </Header>
-            <CardGroup>
-                <Card>
+            <CardGroup className="flex justify-center">
+                <Card className="m-auto min-w-[40rem] max-w-[63rem]">
                     <CardHeader>
                         <h1 className="font usa-card__heading font-bold py-2">Meeting Spaces</h1>
-                        <p className="font-sans text-base-darker text-left">
+                        <p className="font-sans text-base-darker text-left mx-4">
                             Austin Public Library Meeting Spaces are
                             <strong className="font-bold"> free of charge</strong> and ideal for
                             discussion groups, panels, and lectures. Both paper and online

--- a/tailwindcss-uswds/tokens/components.json
+++ b/tailwindcss-uswds/tokens/components.json
@@ -72,10 +72,7 @@
         "WebkitFontSmoothing": "inherit",
         "color": "#71767a",
         "boxShadow": "none",
-        "textAlign": [
-            "left",
-            "center"
-        ],
+        "textAlign": ["left", "center"],
         "cursor": "pointer",
         "backgroundColor": "#0000",
         "backgroundPosition": "50%",
@@ -145,10 +142,7 @@
         "WebkitFontSmoothing": "inherit",
         "color": "#71767a",
         "boxShadow": "none",
-        "textAlign": [
-            "left",
-            "center"
-        ],
+        "textAlign": ["left", "center"],
         "cursor": "pointer",
         "backgroundColor": "#0000",
         "backgroundPosition": "50%",
@@ -215,10 +209,7 @@
         "WebkitFontSmoothing": "inherit",
         "color": "#71767a",
         "boxShadow": "none",
-        "textAlign": [
-            "left",
-            "center"
-        ],
+        "textAlign": ["left", "center"],
         "cursor": "pointer",
         "backgroundColor": "#0000",
         "backgroundPosition": "50%",
@@ -7245,10 +7236,7 @@
         "WebkitFontSmoothing": "inherit",
         "color": "#fff",
         "boxShadow": "none",
-        "textAlign": [
-            "left",
-            "center"
-        ],
+        "textAlign": ["left", "center"],
         "textTransform": "uppercase",
         "backgroundColor": "#005ea2",
         "border": "0",
@@ -8168,10 +8156,7 @@
         "WebkitFontSmoothing": "inherit",
         "color": "currentColor",
         "boxShadow": "none",
-        "textAlign": [
-            "left",
-            "center"
-        ],
+        "textAlign": ["left", "center"],
         "cssFloat": "right",
         "backgroundColor": "#0000",
         "backgroundImage": "none",


### PR DESCRIPTION
### Implementation Detail:
 - Add meeting spaces header image with responsive layout
 - Adjust responsive layout for existing `<CardGroup>` components
 - Implement `<Breadcrumb>` components

### Blockers:
 - Issue with `<Breadcrumb>` component styling; the browser seems to be applying a style of:
 ```
.usa-breadcrumb__list-item {
  position: absolute;
  left: -999rem;
}
```
 to the `<Breadcrumb>` component. Local styling files  (`components.json`) don't indicate any of those styles. Further digging is needed to indicate why that's occurring. 